### PR TITLE
Make final adjustments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
         run: parallel --halt now,fail=1 -- latexmk -cd ':::' examples/*.tex
       - name: Typeset article
         run: latexmk tb140starynovotny-markdown.ltx
+      - name: Check that there are fewer than or exactly 10 pages
+        run: test `tail tb140starynovotny-markdown.log | sed -rn 's/.*\(([0-9]*) pages.*/\1/p'` -le 10
       - name: Archive sources
         run: zip -@ tb140starynovotny-markdown < MANIFEST
       - name: Upload artifacts

--- a/examples/answers/answer-key.sty
+++ b/examples/answers/answer-key.sty
@@ -9,8 +9,7 @@
   { import = istqb / sample-exam }
 \markdownSetupSnippet
   { answer-key }
-  {
-    snippet = istqb / sample-exam
+  { snippet = istqb / sample-exam
       / questions,
     renderers = {
       jekyllDataEnd = {
@@ -31,7 +30,8 @@
         \tablelasttail { \hline }
         \tl_set:Nn
           \l_istqb_answer_key_table_tl
-          { \begin
+          {
+            \begin
               { supertabular }
               { | C { 1.9cm } | C { 1.5cm }
                 | C { 2.4cm } | C { 1.4cm }
@@ -99,7 +99,4 @@
           { \end { supertabular } }
         \tl_use:N
           \l_istqb_answer_key_table_tl
-        \end { multicols }
-      },
-    },
-  }
+        \end { multicols } }}}

--- a/examples/answers/answers.sty
+++ b/examples/answers/answers.sty
@@ -4,15 +4,15 @@
   { 11.15cm }
 \markdownSetupSnippet
   { answers }
-  {
-    snippet = istqb / sample-exam
+  { snippet = istqb / sample-exam
       / questions,
     renderers = {
       jekyllDataEnd = {
         \group_begin:
         \tl_set:Nn
           \l_istqb_answers_table_tl
-          { \begin
+          {
+            \begin
               { longtable }
               { | C { 1.9cm } | C { 1.5cm }
                 | p
@@ -57,16 +57,13 @@
               \l_istqb_answers_table_tl
               { \clist_use:Nn
                   \l_tmpa_clist
-                  { ,~ } &
-              }
+                  { ,~ } & }
             \tl_put_right:Nn
               \l_istqb_answers_table_tl
-              {
-                \begin
+              { \begin
                   { minipage }
                   [ t ]
-                  \c_explanation_width_dim
-              }
+                  \c_explanation_width_dim }
             \prop_get:cnN
               { g_istqb_question_explanation
                 _prop }
@@ -119,14 +116,10 @@
               \l_tmpa_tl
             \tl_put_right:Nn
               \l_istqb_answers_table_tl
-              { \\ \hline }
-          }
+              { \\ \hline } }
         \tl_put_right:Nn
           \l_istqb_answers_table_tl
           { \end { longtable } }
         \tl_use:N
           \l_istqb_answers_table_tl
-        \group_end:
-      },
-    },
-  }
+        \group_end: }}}

--- a/examples/questions.sty
+++ b/examples/questions.sty
@@ -1,69 +1,52 @@
 \keys_define:nn
   { istqb / questions }
-  {
-    num-questions .int_gset:N =
+  { num-questions .int_gset:N =
       \g_istqb_num_questions_int,
     max-score .int_gset:N =
       \g_istqb_max_score_int,
     pass-score .int_gset:N =
-      \g_istqb_pass_score_int,
-  }
+      \g_istqb_pass_score_int }
 \keys_define:nn
   { istqb / questions / duration }
-  {
-    1 .int_gset:N =
+  { 1 .int_gset:N =
       \g_istqb_duration_min_int,
     2 .int_gset:N =
-      \g_istqb_duration_max_int,
-  }
+      \g_istqb_duration_max_int }
 \seq_new:N \g_istqb_questions_seq
 \markdownSetupSnippet
   { questions }
-  {
-    jekyllData,
+  { jekyllData,
     expectJekyllData,
     renderers = {
       jekyllDataBegin = {
         \seq_gclear:N
-          \g_istqb_questions_seq
-      },
+          \g_istqb_questions_seq },
       jekyllData(String|Number) = {
         \keys_set:nn
           { istqb / questions }
-          { { #1 } = { #2 } }
-      },
+          { { #1 } = { #2 } }},
       jekyllDataMappingBegin = ,
       jekyllDataSequenceBegin = {
         \str_case:nn
           { #1 }
-          {
-            { duration } {
+          { { duration } {
               \markdownSetup
-                {
-                  code = \group_begin:,
+                { code = \group_begin:,
                   renderers = {
                     jekyllData(String
                               |Number) = {
                       \keys_set:nn
                         { istqb / questions /
                           duration }
-                        { { ##1 } = { ##2 } }
-                    },
+                        {{ ##1 } = { ##2 }}},
                     jekyllDataSequenceEnd =
-                      \group_end:
-                  },
-                }
-            }
-          }
-      },
+                      \group_end: }}}}},
       jekyllData(Mapping|Sequence)Begin += {%\linelabel{pattern:01:begin}%
         \str_case:nn
           { #1 }
-          {
-            { questions } {
+          { { questions } {
               \markdownSetup
-                {
-                  code = \group_begin:,
+                { code = \group_begin:,
                   renderers = {
                     jekyllData(Mapping
                               |Sequence)End =
@@ -74,18 +57,10 @@
                   renderers = {
                     jekyllData(Mapping
                               |Sequence)End
-                      += \group_end:
-                  },
-                }
-            }
-          }
-      },%\linelabel{pattern:01:end}%
-    },
-  }
+                      += \group_end: }}}}}}}%\linelabel{pattern:01:end}%
 \markdownSetupSnippet
   { questions / list }
-  {
-    renderers = {
+  { renderers = {
       jekyllDataMappingBegin = {%\linelabel{pattern:02:begin}%
         \group_begin:
         \tl_set:Nn
@@ -95,20 +70,13 @@
           \g_istqb_questions_seq
           \l_istqb_current_question_tl
         \markdownSetup
-          {
-            renderers = {
-              jekyllDataMappingEnd =
-            },
+          { renderers = {
+              jekyllDataMappingEnd = },
             snippet = istqb / sample-exam
               / questions / *,
             renderers = {
               jekyllDataMappingEnd +=
-                \group_end:
-            },
-          }
-      },%\linelabel{pattern:02:end}%
-    },
-  }
+                \group_end: }}}}}%\linelabel{pattern:02:end}%
 \prop_new:N
   \g_istqb_question_number_of_points_prop
 \prop_new:N
@@ -121,57 +89,46 @@
   \g_istqb_question_text_prop
 \keys_define:nn
   { istqb / questions / * }
-  {
-    number-of-points .code:n = {
+  { number-of-points .code:n = {
       \prop_gput:cVn
         { g_istqb_question_number_of_points
           _prop }
         \l_istqb_current_question_tl
-        { #1 }
-    },
+        { #1 } },
     learning-objective .code:n = {
       \prop_gput:cVn
         { g_istqb_question_learning_objective
           _prop }
         \l_istqb_current_question_tl
-        { #1 }
-    },
+        { #1 } },
     k-level .code:n = {
       \prop_gput:NVn
         \g_istqb_question_k_level_prop
         \l_istqb_current_question_tl
-        { #1 }
-    },
+        { #1 } },
     explanation .code:n = {
       \prop_gput:NVn
         \g_istqb_question_explanation_prop
         \l_istqb_current_question_tl
-        { #1 }
-    },
+        { #1 } },
     question .code:n = {
       \prop_gput:NVn
         \g_istqb_question_text_prop
         \l_istqb_current_question_tl
-        { #1 }
-    },
-  }
+        { #1 } }}
 \markdownSetupSnippet
   { questions / * }
-  {
-    renderers = {
+  { renderers = {
       jekyllData(String|Number) = {
         \keys_set:nn
           { istqb / questions / * }
-          { { #1 } = { #2 } }
-      },
+          { { #1 } = { #2 } }},
       jekyllDataSequenceBegin = {%\linelabel{pattern:03:begin}%
         \str_case:nn
           { #1 }
-          {
-            { correct } {
+          { { correct } {
               \markdownSetup
-                {
-                  code = \group_begin:,
+                { code = \group_begin:,
                   renderers = {
                     jekyllDataSequenceEnd =
                   },
@@ -180,36 +137,21 @@
                     / * / correct,
                   renderers = {
                     jekyllDataSequenceEnd +=
-                      \group_end:
-                  },
-                }
-            }
-          }
-      },
+                      \group_end: }}}}},
       jekyllDataMappingBegin = {
         \str_case:nn
           { #1 }
-          {
-            { answers } {
+          { { answers } {
               \markdownSetup
-                {
-                  code = \group_begin:,
+                { code = \group_begin:,
                   renderers = {
-                    jekyllDataMappingEnd =
-                  },
+                    jekyllDataMappingEnd = },
                   snippet = istqb
                     / sample-exam / questions
                     / * / answers,
                   renderers = {
                     jekyllDataMappingEnd +=
-                      \group_end:
-                  },
-                }
-            }
-          }
-      },%\linelabel{pattern:03:end}%
-    },
-  }
+                      \group_end: }}}}}}}%\linelabel{pattern:03:end}%
 \prop_new:N \g_istqb_answer_keys_prop
 \prop_new:N \g_istqb_answers_prop
 \seq_new:N \l_istqb_current_answer_keys_seq
@@ -217,8 +159,7 @@
   \l_istqb_current_answer_keys_clist
 \markdownSetupSnippet
   { questions / * / answers }
-  {
-    renderers = {
+  { renderers = {
       jekyllData(String|Number) = {
         \seq_put_right:Nn
           \l_istqb_current_answer_keys_seq
@@ -232,19 +173,16 @@
         \prop_gput:NVn
           \g_istqb_answers_prop
           \l_tmpa_tl
-          { #2 }
-      },
+          { #2 } },
       jekyllDataMappingEnd += {
         \clist_set_from_seq:NN
           \l_istqb_current_answer_keys_clist
           \l_istqb_current_answer_keys_seq
-        \prop_gput:NVV
+        \prop_gput:NVv
           \g_istqb_answer_keys_prop
           \l_istqb_current_question_tl
-          \l_istqb_current_answer_keys_clist
-      },
-    },
-  }
+          { l_istqb_current_answer_keys
+            _clist } }}}
 \prop_new:N
   \g_istqb_answer_correct_keys_prop
 \seq_new:N
@@ -253,14 +191,12 @@
   \l_istqb_current_answer_correct_keys_clist
 \markdownSetupSnippet
   { questions / * / correct }
-  {
-    renderers = {
+  { renderers = {
       jekyllData(String|Number) = {
         \seq_put_right:cn
           { l_istqb_current_answer_correct
             _keys_seq }
-          { #2 }
-      },
+          { #2 } },
       jekyllDataSequenceEnd += {
         \clist_set_from_seq:cc
           { l_istqb_current_answer_correct
@@ -271,7 +207,4 @@
           \g_istqb_answer_correct_keys_prop
           \l_istqb_current_question_tl
           { l_istqb_current_answer_correct
-            _keys_clist }
-      },
-    },
-  }
+            _keys_clist } }}}

--- a/examples/questions/questions.sty
+++ b/examples/questions/questions.sty
@@ -1,18 +1,14 @@
 \markdownSetup
   { import = istqb / sample-exam }
-\tl_new:N
-  \l_istqb_question_tl
 \markdownSetupSnippet
   { questions }
-  {
-    snippet = istqb / sample-exam
+  { snippet = istqb / sample-exam
       / questions,
     renderers = {
       jekyllDataEnd = {
         \seq_map_inline:Nn
           \g_istqb_questions_seq
-          {
-            \tl_set:Nn
+          { \tl_set:Nn
               \l_istqb_question_tl
               {
                 \tl_set:Nn
@@ -31,11 +27,9 @@
                   { ~Point }
                 \int_compare:VNnF
                   \l_tmpb_tl = { 1 }
-                  {
-                    \tl_put_right:Nn
+                  { \tl_put_right:Nn
                       \l_tmpa_tl
-                      { s }
-                  }
+                      { s } }
                 \tl_put_right:Nn
                   \l_tmpa_tl
                   { ) }
@@ -61,12 +55,10 @@
                 \begin { enumerate }
                 \clist_map_inline:Nn
                   \l_tmpa_clist
-                  {
-                    \item [ ####1 ) ]
+                  { \item [ ####1 ) ]
                       \prop_item:Nn
                         \g_istqb_answers_prop
-                        { ##1 / ####1 }
-                  }
+                        { ##1 / ####1 } }
                 \end { enumerate }
                 \medskip
                 \prop_get:cnN
@@ -76,16 +68,12 @@
                   \l_tmpa_clist
                 \int_set:Nn
                   \l_tmpa_int
-                  {
-                    \clist_count:N
-                      \l_tmpa_clist
-                  }
+                  { \clist_count:N
+                      \l_tmpa_clist }
                 Select~\int_case:nn
                   { \l_tmpa_int }
-                  {
-                    { 1 } { ONE~option }
-                    { 2 } { TWO~options }
-                  }
+                  { { 1 } { ONE~option }
+                    { 2 } { TWO~options } }
               }
             \vbox_set:NV
               \l_tmpa_box
@@ -94,13 +82,7 @@
               { \box_ht:N \l_tmpa_box }
               >
               { 0.3 \paperheight }
-              {
-                \tl_use:N
-                  \l_istqb_question_tl
-              }
+              { \tl_use:N
+                  \l_istqb_question_tl }
               { \box_use:N \l_tmpa_box }
-            \par
-          }
-      },
-    },
-  }
+            \par }}}}

--- a/tb140starynovotny-markdown.bib
+++ b/tb140starynovotny-markdown.bib
@@ -12,13 +12,15 @@
 
 @article{novotny2021markdown,
   author  = {V\'{i}t Novotn\'{y}},
-  title   = {{M}arkdown 2.10.0: {\LaTeX} themes \& snippets},
+  year    = {2021},
+  title   = {{M}arkdown 2.10.0: {\LaTeX} themes \& snippets,
+two flavors of comments, and LuaMeta{\TeX}},
   journal = {TUGboat},
   volume  = {42},
   number  = {2},
-  year    = {2021},
   pages   = {186--193},
   issn    = {0896-3207},
+  doi     = {10.47397/tb/42-2/tb131novotny-markdown},
 }
 
 @online{istqb2024productbase,

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -88,7 +88,7 @@ In my work, I developed a \LaTeX{} document class and six Markdown themes~\cite{
 
 The \LaTeX{} document class is named \texttt{istqb} and it is stored in file \texttt{template\slash istqb.cls}. It implements the design of all \acro{ISTQB} documents, defines the meaning of common Unicode characters, and defines \LaTeX{} markup such as \cs{istqbunnumbered\-section}, \texttt{\textbackslash istqb\-land\-scape\-begin}, and \texttt{\textbackslash istqb\-land\-scape\-end}.
 
-The Markdown themes are named \texttt{istqb\slash*} and stored in files \texttt{template\slash markdowntheme*.sty}, see also Figure~\ref{fig:class-diagram}. Here is a description of the themes:
+The Markdown themes are named \texttt{istqb\slash*} and stored in files \texttt{template\slash markdowntheme*.tex} and \texttt{*.sty}, see also Figure~\ref{fig:class-diagram}. Here is what they do:
 \begin{itemize}
 \item The theme \texttt{istqb\slash common} enables Markdown syntax extensions, implements the loading of \acro{YAML} language definitions and document metadata into \TeX{} macros, and defines the mapping between Markdown elements and \LaTeX{} markup. The remaining themes are based on this theme and they implement support for specific types of \acro{ISTQB} documents.
 \item The \texttt{istqb\slash body-of-knowledge} and  \texttt{syllabus} themes are used in \acro{ISTQB} Body of Knowledge and Syllabus documents. At the time of writing, the themes implement no extra functionality.
@@ -101,7 +101,7 @@ The Markdown themes are named \texttt{istqb\slash*} and stored in files \texttt{
 \noindent
 \begin{tikzpicture}[every node/.style={inner sep=0pt, outer sep=0pt}]
   \node (wolf) at (0, 0) {\includegraphics[width=\linewidth]{images/detective-wolf.jpg}};
-  \node [above=-4.5mm of wolf, text width=\linewidth, align=justify] {In the rest of this article, I show the main concepts behind Markdown themes on \acro{ISTQB} Sample Exam Questions and Answers documents using the themes \texttt{istqb\slash sample-exam}, \texttt{istqb\slash sample-exam\slash questions}, and \texttt{\slash answers}.};
+  \node [above=-4.5mm of wolf, text width=\linewidth, align=justify] {In the rest of this article, I show the main concepts behind Markdown themes on the example of \acro{ISTQB} Sample Exam Questions and Answers documents that use the themes \texttt{istqb\slash sample-exam\slash questions} and \texttt{\slash answers}.};
   \node [below=3mm of wolf, text width=\linewidth, align=center] {With Markdown themes, your document can wear many different disguises, just like the wolf.};
 \end{tikzpicture}%
 \vspace{-0.65mm}
@@ -234,6 +234,8 @@ Finally, I define snippets \texttt{questions\slash *\slash answers} and \texttt{
 The snippets accumulate potential and correct answer letters in a sequence, respectively. Then, they store the sequence as a comma-list to a dict that uses the current question number as the key.
 
 Moveover, the snippet \texttt{questions\slash *\slash answers} stores potential answer texts to a dict that uses \meta{current question number}\texttt{\slash}\meta{answer letter} as key.
+
+Notice that I used no format-specific code in this section. Therefore, I can use the theme \texttt{istqb\slash sample-exam} with any format that supports expl3 such as plain \TeX{} and \Hologo{ConTeXt}, not just with \LaTeX.
 
 \subsection{Typesetting questions}
 In this section, I describe the snippet \texttt{questions} from theme \texttt{istqb\slash sample-exam\slash questions}. This snippet typesets the list of questions in Figure~\ref{fig:question-definitions}a.

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -218,7 +218,7 @@ The snippet processes question definitions as follows:
 \item Pass the structured field \texttt{answers} to a snippet \texttt{questions\slash *\slash answers}.
 \end{enumerate}
 
-Notice the design pattern on lines \linesref{pattern:01}, \linesref{pattern:02}, and \linesref{pattern:03} that locally applies a \meta{snippet} to an \meta{element}. This pattern redefines the renderer \meta{element}\verb"Begin", which is placed to the output when the \meta{element} starts, as follows:
+Notice the design pattern on lines \linesref{pattern:01}, \linesref{pattern:02}, and \linesref{pattern:03} that locally applies a \meta{snippet} to an \meta{element}.\footnote{Such design patterns can be repetitive and difficult to understand without additional comments in the code. Markdown Enhancement Proposal (\acro{MEP}) 445~\cite{starynovotny2024parametric} envisions support for higher-order snippets that would make it possible to hide such design patterns behind easy-to-read shorthands.} This pattern redefines the renderer \meta{element}\verb"Begin", which is placed to the output when the \meta{element} starts, as follows:
 \begin{enumerate}
 \item Open a \TeX{} group and apply the \meta{snippet}.
 \item Redefine the renderer \meta{element}\verb"End", which is placed to the output when the \meta{element} ends, so that it closes the \TeX{} group.
@@ -316,7 +316,7 @@ Then, I set the heading and the tail of the table:
   {firstline=17, lastline=30}
   {examples/answers/answer-key.sty}
 
-Next, I define a variable with code that typesets the table:
+Next, I define a variable that typesets the table:
 
 \showimplementation
   {firstline=31, lastline=33}

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -143,7 +143,7 @@ The file imports the snippet \texttt{answers} from theme \texttt{istqb\slash sam
 \end{enumerate}
 
 \section{Implementation}
-In this section, I show how the themes \texttt{istqb\slash sample\hyphen exam\slash questions}, and \texttt{\slash answers} are implemented.
+In this section, I show the implementation of \acro{ISTQB} Sample Exam Questions and Answers documents. To make programming easier, I use the high-level expl3 language in addition to plain \TeX{} and \LaTeXe.
 
 \subsection{Processing question definitions}
 Both the snippet \texttt{questions} from the theme \texttt{istqb\slash sample-exam\slash questions} and the snippet \texttt{answers} from the theme \texttt{\slash answers} process question definitions before typesetting them. For the processing, they use the snippet \texttt{questions} from the theme \texttt{istqb\slash sample-exam}, which I describe in this section.

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -243,47 +243,47 @@ In this section, I describe the snippet \texttt{questions} from theme \texttt{is
 First, I import the theme \texttt{istqb\slash sample-exam} and I use the snippet \texttt{questions} from this theme to process question definitions:
 
 \showimplementation
-  {firstnumber=1, lastline=9}
+  {firstnumber=1, lastline=6}
   {examples/questions/questions.sty}
 
 After the question definitions have been processed, I iterate over all question numbers. For each question number, I define a variable with code that typesets the corresponding question:
 
 \showimplementation
-  {firstline=10, lastline=17}
+  {firstline=7, lastline=13}
   {examples/questions/questions.sty}
 
 \noindent
 First, I add a section heading for the question:
 
 \showimplementation
-  {firstline=18, lastline=53}
+  {firstline=14, lastline=47}
   {examples/questions/questions.sty}
 
 \noindent
 Next, I add the question text and potential answers:
 
 \showimplementation
-  {firstline=54, lastline=70}
+  {firstline=48, lastline=63}
   {examples/questions/questions.sty}
 
 \noindent
 Lastly, I add the text ``Select \meta{number of correct answers} option(s).'':
 
 \showimplementation
-  {firstline=71, lastline=89}
+  {firstline=64, lastline=77}
   {examples/questions/questions.sty}
 
 Finally, I typeset the code from the variable at natural height and store the result to a vertical box:
 
 \showimplementation
-  {firstline=90, lastline=92}
+  {firstline=78, lastline=80}
   {examples/questions/questions.sty}
 
 \noindent
 For short questions, I insert the box to the current list for typesetting to prevent page breaks within the question. For longer questions, I place the content of the variable to the input stream, so that page breaks can occur naturally:
 
 \showimplementation
-  {firstline=93}
+  {firstline=81}
   {examples/questions/questions.sty}
 
 \subsection{Typesetting answer key}
@@ -301,25 +301,25 @@ The packages allow me to typeset the answer key as a table in a two-column layou
 Next, I import the theme \texttt{istqb\slash sample-exam} and I use the snippet \texttt{questions} from this theme to process question definitions:
 
 \showimplementation
-  {firstline=8, lastline=14}
+  {firstline=8, lastline=13}
   {examples/answers/answer-key.sty}
 
 After the question definitions have been processed, I start a two-column layout:
 
 \showimplementation
-  {firstline=15, lastline=17}
+  {firstline=14, lastline=16}
   {examples/answers/answer-key.sty}
 
 Then, I set the heading and the tail of the table:
 
 \showimplementation
-  {firstline=18, lastline=31}
+  {firstline=17, lastline=30}
   {examples/answers/answer-key.sty}
 
 Next, I define a variable with code that typesets the table:
 
 \showimplementation
-  {firstline=32, lastline=33}
+  {firstline=31, lastline=33}
   {examples/answers/answer-key.sty}
 
 \noindent
@@ -396,7 +396,7 @@ In this section, I describe the snippet \texttt{answers} from the theme \texttt{
 First, I load package longtable:
 
 \showimplementation
-  {firstnumber=1, lastline=1}
+  {firstnumber=1, lastline=4}
   {examples/answers/answers.sty}
 
 \noindent
@@ -405,13 +405,13 @@ The package allows me to typeset the list of answers as a table that automatical
 Next, I use snippet the \texttt{questions} from theme \texttt{istqb\slash sample\hyphen exam} to process question definitions:
 
 \showimplementation
-  {firstline=2, lastline=9}
+  {firstline=5, lastline=8}
   {examples/answers/answers.sty}
 
 After the question definitions have been processed, I define a variable that typesets the table:
 
 \showimplementation
-  {firstline=10, lastline=14}
+  {firstline=9, lastline=14}
   {examples/answers/answers.sty}
 
 \noindent
@@ -439,14 +439,14 @@ For each question, I add the question number:
 Next, I add the correct answer letters:
 
 \showimplementation
-  {firstline=51, lastline=61}
+  {firstline=51, lastline=60}
   {examples/answers/answers.sty}
 
 \noindent
 Then I add the explanation text:
 
 \showimplementation
-  {firstline=62, lastline=81}
+  {firstline=61, lastline=81}
   {examples/answers/answers.sty}
 
 \noindent
@@ -467,20 +467,20 @@ Lastly, I add the K-level:
 Lastly, I add the number of points:
 
 \showimplementation
-  {firstline=109, lastline=120}
+  {firstline=109, lastline=119}
   {examples/answers/answers.sty}
 
 \noindent
 After I have iterated over all question numbers, I end the table:
 
 \showimplementation
-  {firstline=121, lastline=123}
+  {firstline=120, lastline=122}
   {examples/answers/answers.sty}
 
 Then, I place the content of the variable to the input stream:
 
 \showimplementation
-  {firstline=124}
+  {firstline=123}
   {examples/answers/answers.sty}
 
 \section*{Conclusion}

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -484,9 +484,12 @@ Then, I place the content of the variable to the input stream:
   {examples/answers/answers.sty}
 
 \section*{Conclusion}
-In this article, I demonstrated the practical application of Markdown themes using \acro{ISTQB} Sample Exam Questions and Answers documents as an example.
 
-Whereas my previous article~\cite{novotny2021markdown} focused on the concepts behind Markdown themes, this article provides concrete code used in a real-world software project. I hope this practical lesson will raise awareness of Markdown themes and illustrate how users can incorporate themes into their own projects.
+In this article, I have demonstrated the practical application of Markdown themes through a project that enabled the International Software Testing Qualifications Board (\acro{ISTQB}) to produce their certification study materials from Markdown and \acro{YAML} sources. While my previous article~\cite{novotny2021markdown} focused on the underlying concepts of Markdown themes, this article provides concrete code used in a real-world software project. I hope this practical demonstration raises awareness of Markdown themes and illustrates how users can incorporate them into their own projects.
+
+For \acro{ISTQB}, the project for has yielded numerous benefits: Writing text in a structured format using Markdown and \acro{YAML}, while generating visually appealing outputs with \LaTeX{}, facilitates the separation of content from formatting. This ensures consistent application of the document's visual style across all \acro{ISTQB} content. Additionally, the structured text enables content verification against \acro{YAML} schemas and \acro{ISTQB} writing rules and allows for the creation of a complex knowledge base through automated processing. This enhances the quality of learning materials and reduces administrative overhead.
+
+Moreover, the plain text formats of Markdown and \acro{YAML} offer significant advantages over binary formats like Microsoft Office. They allow for efficient version control, better tracking of changes, collaborative editing, and fewer defects in the final products. The capability to produce various output formats, such as \acro{EPUB}, \acro{HTML}, and \acro{PDF} with functional hyperlinks and cross-references, further amplifies the utility of this approach.
 
 \section*{Acknowledgements}
 I wish to extend my special thanks to Tereza Vrabcová, Marei Peischl, Daniel Po\v{l}an, and Petr Sojka for their invaluable insights and thorough review of our work. Their expertise and thoughtful feedback have been instrumental in shaping the final manuscript.

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -152,7 +152,7 @@ Both the snippet \texttt{questions} from the theme \texttt{istqb\slash sample-ex
 First, I define a key--value \texttt{istqb\slash questions}:
 
 \showimplementation
-  {firstnumber=1, firstline=1, lastline=10}
+  {firstnumber=1, firstline=1, lastline=8}
   {examples/questions.sty}
 
 \noindent
@@ -161,7 +161,7 @@ The key--value stores the values in top-level unstructured fields \texttt{num-qu
 Next, I define a key--value \texttt{istqb\slash questions\slash duration}:
 
 \showimplementation
-  {firstline=11, lastline=18}
+  {firstline=9, lastline=14}
   {examples/questions.sty}
 
 \noindent
@@ -170,7 +170,7 @@ The key--value stores the values in the top-level structured field \texttt{durat
 Then, I define the snippet \texttt{questions} itself:
 
 \showimplementation
-  {firstline=19, lastline=84}
+  {firstline=15, lastline=60}
   {examples/questions.sty}
 
 \noindent
@@ -185,7 +185,7 @@ The snippet processes question definitions as follows:
 Next, I define the snippet \texttt{questions/list}:
 
 \showimplementation
-  {firstline=85, lastline=111}
+  {firstline=61, lastline=79}
   {examples/questions.sty}
 
 \noindent
@@ -198,7 +198,7 @@ The snippet processes each question as follows:
 Then, I define key--value \texttt{istqb\slash questions\slash *}:
 
 \showimplementation
-  {firstline=112, lastline=157}
+  {firstline=80, lastline=118}
   {examples/questions.sty}
 
 \noindent
@@ -207,7 +207,7 @@ The key--value stores the values in unstructured fields \texttt{number\hyphen of
 Next, I define the snippet \texttt{questions/*}:
 
 \showimplementation
-  {firstline=158, lastline=212}
+  {firstline=119, lastline=154}
   {examples/questions.sty}
 
 \noindent
@@ -227,7 +227,7 @@ Notice the design pattern on lines \linesref{pattern:01}, \linesref{pattern:02},
 Finally, I define snippets \texttt{questions\slash *\slash answers} and \texttt{\slash correct}:
 
 \showimplementation
-  {firstline=213}
+  {firstline=155}
   {examples/questions.sty}
 
 \noindent

--- a/tb140starynovotny-markdown.ltx
+++ b/tb140starynovotny-markdown.ltx
@@ -44,8 +44,8 @@
 \title{Markdown themes in practice}
 
 % repeat info for each author; comment out items that don't apply.
-\author{Vít Starý Novotný}
-\address{Studená 453/15 \\ Brno 63800, Czech Republic}
+\author{V\'{i}t Star\'{y} Novotn\'{y}}
+\address{Studen\'{a} 453/15 \\ Brno 63800, Czech Republic}
 \netaddress{witiko (at) mail dot muni dot cz}
 \personalURL{github.com/witiko}
 
@@ -485,6 +485,11 @@ Then, I place the content of the variable to the input stream:
 In this article, I demonstrated the practical application of Markdown themes using \acro{ISTQB} Sample Exam Questions and Answers documents as an example.
 
 Whereas my previous article~\cite{novotny2021markdown} focused on the concepts behind Markdown themes, this article provides concrete code used in a real-world software project. I hope this practical lesson will raise awareness of Markdown themes and illustrate how users can incorporate themes into their own projects.
+
+\section*{Acknowledgements}
+I wish to extend my special thanks to Tereza Vrabcová, Marei Peischl, Daniel Po\v{l}an, and Petr Sojka for their invaluable insights and thorough review of our work. Their expertise and thoughtful feedback have been instrumental in shaping the final manuscript.
+
+I would also like to thank Greg at \url{https://fiverr.com/quickcartoon} for their illustrations of the wolf mascot, which has provided an engaging visual identity of the Markdown package over the past four years.
 
 \SetBibJustification{\raggedright \advance\itemsep by 2pt plus1pt minus1pt}
 \bibliographystyle{tugboat}


### PR DESCRIPTION
This PR makes the final adjustments before the submission of the preprint to TUG 2024 organizers:

- [x] Explicitly state that themes are written in expl3.
- [x] Make implementation code more concise.
- [x] Add ISTQB's blurb about the template to the Conclusion.
- [x] Add Acknowledgements.
- [x] Add back footnote about https://github.com/Witiko/markdown/discussions/445 from https://github.com/Witiko/markdown-themes-in-practice/commit/2183fc4d08593732c6ee7e6a04f653daf67c770c#diff-5d89524726602dbde49c37a447c787badfbe9c673c509e1fd6bfe63bece049e4R156.